### PR TITLE
Adds changing the directory before viewing dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ The recommended workflow is
 
 Just clone your Rails fork into the rails-dev-box directory on the host computer:
 
+    host $ cd /vagrant
     host $ ls
     bootstrap.sh MIT-LICENSE README.md Vagrantfile
     host $ git clone git@github.com:<your username>/rails.git


### PR DESCRIPTION
When you ssh into the virtual machine you are taken to /home/vagrant instead of /vagrant which could be confusing.
This commit just adds the change directory to the list of steps.

PS Thanks for creating this, it saves so much time when contributing!
